### PR TITLE
Significant progress on 'network' netnses.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,22 @@ jobs:
         - "debian-clang:testing"
         - "debian-clang:unstable"
 
-        - "ubuntu-clang:rolling"
+        - "debian-gcc10:testing"
+        - "debian-gcc10:unstable"
+
+        - "ubuntu-clang:eoan"
+        - "ubuntu-clang:focal"
         - "ubuntu-clang:devel"
+
+        - "ubuntu-gcc10:focal"
+        - "ubuntu-gcc10:devel"
+
+        - "fedora-clang:31"
+        - "fedora-clang:32"
+        - "fedora-clang:rawhide"
+
+        - "fedora-gcc:32"
+        - "fedora-gcc:rawhide"
 
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/*
+build-*
 compile_flags.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,19 @@ project(nonsense CXX)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 20)
 
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 10.0.0)
+        message(FATAL_ERROR "Your compiler does not support C++ coroutines;
+            the earliest GCC version to do so is GCC 10.")
+    endif()
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcoroutines")
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcoroutines-ts")
+else ()
+    message(FATAL_ERROR "Your compiler has no known way of enabling C++ coroutines.")
+endif()
+
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "/usr" CACHE STRING
         "Install path prefix, prepended onto install directories." FORCE)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Probably not yet, but I'm just a README, not your parent.
 Build requirements are as follows:
 
   * CMake 3.12 or higher;
-  * a C++20 compiler with coroutines support (as of Dec '19, this means Clang 5 or higher, with libc++);
+  * a C++20 compiler with coroutines support (as of Apr '20, this means GCC 10 or higher or Clang 7 or higher;
+  Clang 5 and 6 both support coroutines, but they do not support promise constructor parameter preview, which
+  is a feature that's used extensively in Nonsense),
   * libsystemd, version 242 or higher (based on the systems Nonsense is tested on).
 
 ### ...to run it?

--- a/control/CMakeLists.txt
+++ b/control/CMakeLists.txt
@@ -18,6 +18,7 @@ set_target_properties(
 target_link_libraries(
     nonsensectl
     ${SYSTEMD_LDFLAGS}
+    ${CMAKE_DL_LIBS}
 )
 
 install(

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -18,6 +18,7 @@ set_target_properties(
 target_link_libraries(
     nonsensed
     ${SYSTEMD_LDFLAGS}
+    ${CMAKE_DL_LIBS}
 )
 
 install(

--- a/daemon/async.h
+++ b/daemon/async.h
@@ -1,0 +1,616 @@
+/*
+ * Copyright © 2020 Michał 'Griwes' Dominiak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "bus_slot.h"
+#include "log_helpers.h"
+#include "overloads.h"
+
+#include <cassert>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <tuple>
+#include <variant>
+#include <vector>
+
+// TODO: GCC appears to have a bug and not define the coroutine feature test macros correctly. If it did, the
+// __has_includes would turn into `defined(__cpp_impl_coroutine)` for the IS and `defined(__cpp_coroutines)`
+// for the TS.
+#if __has_include(<coroutine>)
+// C++20 coroutines
+#include <coroutine>
+
+namespace nonsensed
+{
+namespace coro = std;
+}
+#elif __has_include(<experimental/coroutine>)
+// Coroutines TS
+#include <experimental/coroutine>
+
+namespace nonsensed
+{
+namespace coro = std::experimental;
+}
+#else
+#error no coroutines support detected!
+#endif
+
+#define RETURN_TASK                                                                                          \
+    return [=]([[maybe_unused]] coro::coroutine_handle<promise> nonsense_promise_arg) -> future
+
+// This macro should not need to exist.
+//
+// It does need to exist, however, because the heuristics for language detection in clangd's clang-format are
+// DUUUUUUUUMB and decide that if you `#define foo [=, this]`, that SURELY means that you're writing code in
+// ObjC, right? RIGHT?!
+//
+// AAAAAAAAAAAAAAAAAAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.
+#define NONSENSE_SQUARE [
+
+#define RETURN_MEMBER_TASK                                                                                   \
+    return NONSENSE_SQUARE =, this]([[maybe_unused]] coro::coroutine_handle<promise> nonsense_promise_arg)   \
+    -> future
+
+namespace nonsensed
+{
+struct reply_error_t
+{
+    sd_bus_error error = SD_BUS_ERROR_NULL;
+};
+
+inline reply_error_t reply_error_const(const char * name, const char * description)
+{
+    reply_error_t ret;
+    sd_bus_error_set_const(&ret.error, name, description);
+    return ret;
+}
+
+template<typename... Ts>
+reply_error_t reply_error_format(const char * name, const char * format, Ts... ts)
+{
+    reply_error_t ret;
+    sd_bus_error_setf(&ret.error, name, format, ts...);
+    return ret;
+}
+
+struct reply_status_t
+{
+    int code;
+    sd_bus_error error = SD_BUS_ERROR_NULL;
+};
+
+inline reply_status_t reply_status(int code)
+{
+    return { code };
+}
+
+inline reply_status_t reply_status(int code, const sd_bus_error * error)
+{
+    reply_status_t ret{ code };
+    sd_bus_error_copy(&ret.error, error);
+    return ret;
+}
+
+inline reply_status_t reply_status_const(int code, const char * name, const char * description)
+{
+    reply_status_t ret{ code };
+    sd_bus_error_set_const(&ret.error, name, description);
+    return ret;
+}
+
+template<typename... Ts>
+reply_status_t reply_status_format(int code, const char * name, const char * format, Ts... ts)
+{
+    reply_status_t ret{ code };
+    sd_bus_error_setf(&ret.error, name, format, ts...);
+    return ret;
+}
+
+struct maybe_reply_status_t
+{
+    int code;
+};
+
+inline maybe_reply_status_t log_and_reply_on_error(int code, const char * message)
+{
+    if (code < 0)
+    {
+        std::cerr << error_prefix() << "Error: " << message << ": " << strerror(-code) << '\n';
+    }
+    return { code };
+}
+
+class promise;
+
+class future
+{
+public:
+    using promise_type = promise;
+};
+
+inline constexpr struct unit_t
+{
+} unit;
+
+template<typename Signature>
+struct function;
+
+using subtask = function<future(coro::coroutine_handle<promise>)>;
+
+class promise
+{
+public:
+    template<typename Class>
+    promise(const Class &, sd_bus_message * message, sd_bus_error * error)
+        : _payload(sd_bus_message_ref(message))
+    {
+    }
+
+    promise(coro::coroutine_handle<promise> handle) : _payload(std::move(handle))
+    {
+    }
+
+    template<typename Class>
+    promise(const Class &, coro::coroutine_handle<promise> handle) : _payload(std::move(handle))
+    {
+    }
+
+    ~promise()
+    {
+        std::visit(
+            overload{ [](sd_bus_message * message) { sd_bus_message_unref(message); },
+                      [](coro::coroutine_handle<promise> handle) {} },
+            _payload);
+    }
+
+    coro::suspend_never initial_suspend()
+    {
+        return {};
+    }
+
+    coro::suspend_never final_suspend()
+    {
+        return {};
+    }
+
+    // Error replies.
+    void return_value(const reply_error_t & error)
+    {
+        std::visit(
+            overload{ [&](sd_bus_message * message) {
+                         int result = sd_bus_reply_method_error(message, &error.error);
+                         if (result < 0)
+                         {
+                             std::cerr << "Error while handling an error in " << __PRETTY_FUNCTION__ << ": "
+                                       << strerror(-result) << '\n';
+                             std::abort();
+                         }
+                     },
+                      [&](coro::coroutine_handle<promise> handle) {
+                          handle.promise().return_value(error);
+                          handle.destroy();
+                      } },
+            _payload);
+    }
+
+    void return_value(const reply_status_t & status)
+    {
+        std::visit(
+            overload{ [&](sd_bus_message * message) {
+                         if (status.code < 0)
+                         {
+                             int result = sd_bus_reply_method_errno(message, status.code, &status.error);
+                             if (result < 0)
+                             {
+                                 std::cerr << "Error while handling an error in " << __PRETTY_FUNCTION__
+                                           << ": " << strerror(-result) << '\n';
+                                 std::abort();
+                             }
+                         }
+                     },
+                      [&](coro::coroutine_handle<promise> handle) {
+                          handle.promise().return_value(status);
+                          handle.destroy();
+                      } },
+            _payload);
+    }
+
+    // "void"-returning sub-promises.
+    void return_value(unit_t)
+    {
+        std::visit(
+            overload{ [](sd_bus_message * message) {
+                         std::cerr << "Fatal error: attempted to return void from a top-level coroutine.\n";
+                         std::abort();
+                     },
+                      [](coro::coroutine_handle<promise> handle) { handle.resume(); } },
+            _payload);
+    }
+
+    // Maybe-error replies.
+    auto yield_value(const maybe_reply_status_t & status)
+    {
+        struct
+        {
+            const maybe_reply_status_t & status;
+            promise & promise_;
+
+            bool await_ready()
+            {
+                return false;
+            }
+
+            coro::coroutine_handle<> await_suspend(coro::coroutine_handle<> handle)
+            {
+                if (status.code < 0)
+                {
+                    promise_.return_value(reply_status_t{ status.code });
+                    handle.destroy();
+                    return coro::noop_coroutine();
+                }
+
+                return handle;
+            }
+
+            void await_resume()
+            {
+            }
+        } ret{ status, *this };
+
+        return ret;
+    }
+
+    // Sub-coroutines.
+    template<
+        typename U,
+        typename std::enable_if<std::is_invocable_v<U, coro::coroutine_handle<promise>>>::type...>
+    auto await_transform(U u)
+    {
+        struct
+        {
+            U u;
+
+            bool await_ready()
+            {
+                return false;
+            }
+
+            void await_suspend(coro::coroutine_handle<promise> handle)
+            {
+                u(std::move(handle));
+            }
+
+            void await_resume()
+            {
+            }
+        } awaitable{ std::move(u) };
+
+        return awaitable;
+    }
+
+    // All else.
+    template<
+        typename U,
+        typename std::enable_if<!std::is_invocable_v<U, coro::coroutine_handle<promise>>>::type...>
+    auto await_transform(U u)
+    {
+        return u;
+    }
+
+    future get_return_object()
+    {
+        return future();
+    }
+
+    void unhandled_exception()
+    {
+        try
+        {
+            throw;
+        }
+        catch (...)
+        {
+            std::terminate();
+        }
+    }
+
+private:
+    std::variant<sd_bus_message *, coro::coroutine_handle<promise>> _payload;
+};
+
+struct service_description
+{
+    const char * service;
+    const char * dbus_path;
+    const char * interface;
+};
+
+namespace services
+{
+    namespace systemd
+    {
+        inline service_description manager = { .service = "org.freedesktop.systemd1",
+                                               .dbus_path = "/org/freedesktop/systemd1",
+                                               .interface = "org.freedesktop.systemd1.Manager" };
+    }
+}
+
+template<typename... Arguments>
+struct signal_description
+{
+    const service_description & service;
+    const char * name;
+    const char * argument_string;
+};
+
+namespace signals
+{
+    namespace systemd
+    {
+        inline signal_description<std::uint32_t, const char *, const char *, const char *> job_removed = {
+            .service = services::systemd::manager,
+            .name = "JobRemoved",
+            .argument_string = "uoss"
+        };
+    }
+}
+
+namespace async
+{
+    template<typename... Ts>
+    auto sd_bus_call_method(
+        sd_bus * bus,
+        const service_description & service,
+        const char * method,
+        const char * argument_string,
+        Ts... ts)
+    {
+        struct awaitable_t
+        {
+            sd_bus * bus;
+            const service_description & service;
+            const char * method;
+            const char * argument_string;
+            std::tuple<Ts...> arguments;
+
+            sd_bus_message * message = nullptr;
+            coro::coroutine_handle<promise> handle;
+
+            bool await_ready()
+            {
+                return false;
+            }
+
+            void await_suspend(coro::coroutine_handle<promise> handle)
+            {
+                this->handle = std::move(handle);
+
+                std::apply(
+                    [&](Ts... ts) {
+                        assert(
+                            sd_bus_call_method_async(
+                                bus,
+                                nullptr,
+                                service.service,
+                                service.dbus_path,
+                                service.interface,
+                                method,
+                                +[](sd_bus_message * message, void * userdata, sd_bus_error * ret_error) {
+                                    auto & self = *static_cast<awaitable_t *>(userdata);
+
+                                    if (sd_bus_message_is_method_error(message, nullptr))
+                                    {
+                                        self.handle.promise().return_value(reply_status(
+                                            -sd_bus_message_get_errno(message),
+                                            sd_bus_message_get_error(message)));
+                                        self.handle.destroy();
+
+                                        return 1;
+                                    }
+
+                                    sd_bus_message_ref(message);
+                                    self.message = message;
+                                    self.handle();
+
+                                    return 1;
+                                },
+                                this,
+                                argument_string,
+                                ts...)
+                            >= 0);
+                    },
+                    arguments);
+            }
+
+            auto await_resume()
+            {
+                return std::unique_ptr<
+                    sd_bus_message,
+                    std::integral_constant<decltype(&sd_bus_message_unref), &sd_bus_message_unref>>{
+                    message
+                };
+            }
+        } awaitable{ bus, service, method, argument_string, { ts... } };
+
+        return awaitable;
+    }
+
+    template<typename... Arguments>
+    class signal_subscription
+    {
+    public:
+        signal_subscription(sd_bus * bus, const signal_description<Arguments...> & signal)
+            : _bus(bus), _signal(signal)
+        {
+            assert(
+                sd_bus_match_signal(
+                    _bus,
+                    &_slot,
+                    signal.service.service,
+                    signal.service.dbus_path,
+                    signal.service.interface,
+                    signal.name,
+                    +[](sd_bus_message * message, void * userdata, sd_bus_error * ret_error) {
+                        auto & self = *static_cast<signal_subscription *>(userdata);
+
+                        // The loop below is, addmittedly, written in a very weird way. Let me explain.
+                        //
+                        // First of all, we're trying to roughly follow the sd_bus handler mechanics, where
+                        // returning a positive result means that the message has been handled. In that case,
+                        // since the callbacks are one-shot, we want to clear the element out of the set of
+                        // callbacks we want to handle, so that we don't try to invoke it the next time -
+                        // probably because it was a coroutine continuation and those are one shot.
+                        //
+                        // *However*, if this was done naively (like I did initially), i.e. just by calling
+                        // erase inside the early return branch, there's... a problem. Since, in the intended
+                        // use case, a matched signal would cause *the coroutine that owns the subscription*
+                        // to resume, it may also... cause it to end, destroying the subscription. That's bad,
+                        // because it'd cause the call to erase to reach into an already destroyed vector.
+                        // Oops.
+                        //
+                        // So, what do we do to achieve the same effect? Well, we first check if the entry has
+                        // already been cleared, if so then there's nothing for us to do. Then, we replace the
+                        // entry with an empty one, speculatively. It gets restored if the callback didn't
+                        // return a positive value, in which case we want to continue looping (and *hopefully*
+                        // there isn't a bug where the coroutine is destroyed yet a non-positive value is
+                        // provided). If the handler did match, however, we take advantage of the speculative
+                        // clear - to effectively clear an entry in a potentially-already-gone vector, without
+                        // touching the memory of said vector at all.
+                        //
+                        // There's two conditions under which this breaks, one already mentioned:
+                        //   1. The callback ends up destroying the current coroutine and therefore this
+                        //   subscription, but returns 0 or less. In this case, the swap after the branch will
+                        //   reach into deallocated memory. Should be checkable with ASAN.
+                        //   2. The callback ends up *inserting* a new callback into the set, but - again -
+                        //   returns 0 or less. In this case the effect is the same if the vector reallocates
+                        //   its buffer; again, checkable with ASAN.
+                        //
+                        // Both of those result from an error where someone inserted a callback that does not
+                        // behave correctly into the callback queue; if that's you, you should feel bad. This
+                        // is not something we should need to check for too hard, because the callback queue
+                        // is internal and only populated by `match`.
+
+                        for (auto it = self._callbacks.begin(), end = self._callbacks.end(); it != end; ++it)
+                        {
+                            if (it->function == nullptr)
+                            {
+                                continue;
+                            }
+
+                            callback_type elem{};
+                            std::swap(elem, *it);
+
+                            auto result = elem.function(message, elem.userdata, ret_error);
+                            if (result > 0)
+                            {
+                                return result;
+                            }
+
+                            std::swap(elem, *it);
+                        }
+
+                        return 0;
+                    },
+                    this)
+                >= 0);
+        }
+
+        struct callback_type
+        {
+            sd_bus_message_handler_t function;
+            void * userdata;
+        };
+
+        template<std::size_t KeyIndex, typename Key>
+        auto match(Key key)
+        {
+            struct awaitable_t
+            {
+                Key key;
+                signal_subscription & subscription;
+
+                sd_bus_message * message = nullptr;
+                coro::coroutine_handle<promise> handle;
+
+                bool await_ready()
+                {
+                    return false;
+                }
+
+                void await_suspend(coro::coroutine_handle<promise> handle)
+                {
+                    this->handle = std::move(handle);
+
+                    subscription._callbacks.push_back(
+                        { +[](sd_bus_message * message, void * userdata, sd_bus_error * ret_error) {
+                             auto & self = *static_cast<awaitable_t *>(userdata);
+
+                             std::tuple<Arguments...> arguments;
+                             std::apply(
+                                 [&](Arguments &... args) {
+                                     assert(
+                                         sd_bus_message_read(
+                                             message, self.subscription._signal.argument_string, &args...)
+                                         >= 0);
+                                 },
+                                 arguments);
+                             sd_bus_message_rewind(message, true);
+
+                             if (self.key == std::get<KeyIndex>(arguments))
+                             {
+                                 sd_bus_message_ref(message);
+                                 self.message = message;
+
+                                 self.handle();
+                                 return 1;
+                             }
+
+                             return 0;
+                         },
+                          this });
+                }
+
+                auto await_resume()
+                {
+                    return std::unique_ptr<
+                        sd_bus_message,
+                        std::integral_constant<decltype(&sd_bus_message_unref), &sd_bus_message_unref>>{
+                        message
+                    };
+                }
+            } awaitable{ key, *this };
+
+            return awaitable;
+        }
+
+    private:
+        sd_bus * _bus;
+        dbus_slot _slot;
+        const signal_description<Arguments...> _signal;
+
+        std::vector<callback_type> _callbacks;
+    };
+
+    template<typename... Arguments>
+    auto sd_bus_subscribe_signal(sd_bus * bus, const signal_description<Arguments...> & signal)
+    {
+        return signal_subscription<Arguments...>(bus, signal);
+    }
+}
+}

--- a/daemon/bus_slot.h
+++ b/daemon/bus_slot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Michał 'Griwes' Dominiak
+ * Copyright © 2019-2020 Michał 'Griwes' Dominiak
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,19 @@
 
 #include <systemd/sd-bus.h>
 
+#include <utility>
+
 namespace nonsensed
 {
 class dbus_slot
 {
 public:
+    dbus_slot() = default;
+
+    dbus_slot(dbus_slot && other) : _slot{ std::exchange(other._slot, nullptr) }
+    {
+    }
+
     auto operator&()
     {
         return &_slot;
@@ -34,6 +42,11 @@ public:
     }
 
     ~dbus_slot()
+    {
+        reset();
+    }
+
+    void reset()
     {
         sd_bus_slot_unref(_slot);
     }

--- a/daemon/configuration.cpp
+++ b/daemon/configuration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Michał 'Griwes' Dominiak
+ * Copyright © 2019-2020 Michał 'Griwes' Dominiak
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,15 +101,6 @@
  *     No return values.
  *     Semantics: adds an operation of removing an entity from the configuration to the transaction. The
  * entity to delete's kind is identified by the first argument; the name by the second.
- *
- * info.griwes.nonsense.Namespace
- * ==============================
- *
- * info.griwes.nonsense.Network
- * ============================
- *
- * info.griwes.nonsense.Interface
- * ==============================
  */
 
 /**

--- a/daemon/configuration.h
+++ b/daemon/configuration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Michał 'Griwes' Dominiak
+ * Copyright © 2019-2020 Michał 'Griwes' Dominiak
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,16 @@ class configuration
 public:
     configuration(const options & opts);
     void install(const service & srv);
+
+    config & running()
+    {
+        return _running_config;
+    }
+
+    const config & running() const
+    {
+        return _running_config;
+    }
 
 private:
     dbus_slot _bus_slot;

--- a/daemon/controller.cpp
+++ b/daemon/controller.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Michał 'Griwes' Dominiak
+ * Copyright © 2019-2020 Michał 'Griwes' Dominiak
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,33 +14,166 @@
  * limitations under the License.
  */
 
+// TODO: move the docs below into a proper documentation system.
+
+/**
+ * Nonsense runtime management d-bus interfaces
+ * ============================================
+ *
+ * The runtime management part of Nonsense exposes objects of the following d-bus interfaces in its d-bus
+ * tree:
+ *
+ * info.griwes.nonsense.Controller
+ * ===============================
+ *
+ * info.griwes.nonsense.Entity
+ * ===========================
+ * Properties:
+ *  - Kind :: readonly y
+ *    Describes the kind of the entity:
+ *      1 - namespace
+ *      2 - network
+ *      3 - interface
+ *
+ * info.griwes.nonsense.Namespace
+ * ==============================
+ *
+ * info.griwes.nonsense.Network
+ * ============================
+ *
+ * info.griwes.nonsense.Interface
+ * ==============================
+ */
+
+/**
+ * Nonsense runtime management d-bus tree objects
+ * ==============================================
+ *
+ * The /info/griwes/nonsense object is the main interface for controlling and querying the state of
+ * entities managed by Nonsense.
+ *
+ * Under /info/griwes/nonsense. the following sub-objects are exposed:
+ *  - /info/griwes/nonsense/entity, which is the collection of currently managed entities. This subtree also
+ * presents specific objects for every entity.
+ *
+ * /info/griwes/nonsense
+ * =====================
+ * Interface:
+ *  - info.griwes.nonsense.Controller
+ *
+ * /info/griwes/nonsense/entity/...
+ * ================================
+ * Interfaces:
+ *  - info.griwes.nonsense.Entity
+ *  - info.griwes.nonsense.Namespace (if type is netns)
+ *  - info.griwes.nonsense.Network (if type is network)
+ *  - info.griwes.nonsense.Interface (if type is interface)
+ */
+
 #include "controller.h"
 
+#include "common_definitions.h"
+#include "configuration.h"
+#include "log_helpers.h"
 #include "service.h"
 
-#include <systemd/sd-bus.h>
-
+#include <iostream>
 #include <stdexcept>
 #include <string>
 
-static const sd_bus_vtable controller_vtable[] = { SD_BUS_VTABLE_START(0), SD_BUS_VTABLE_END };
-
 namespace nonsensed
 {
-controller::controller(const options & opts, configuration & config_object, const service & srv)
-{
-    int ret;
+DEFINE_METHOD(controller, start);
+DEFINE_METHOD(controller, stop);
 
-    ret = sd_bus_add_object_vtable(
-        srv.bus(),
-        &_slot,
-        "/info/griwes/nonsense/controller",
-        "info.griwes.nonsense.controller",
-        controller_vtable,
-        this);
+static const sd_bus_vtable controller_vtable[] = {
+    SD_BUS_VTABLE_START(0),
+
+    SD_BUS_METHOD("Start", "ys", "", controller::method_start, SD_BUS_VTABLE_UNPRIVILEGED),
+    SD_BUS_METHOD("Stop", "ys", "", controller::method_stop, SD_BUS_VTABLE_UNPRIVILEGED),
+
+    SD_BUS_VTABLE_END
+};
+
+controller::controller(const options & opts, configuration & configuration_object, const service & srv)
+    : _srv{ srv }, _config(configuration_object.running())
+{
+    const char * dbus_path = "/info/griwes/nonsense";
+    int ret = sd_bus_add_object_vtable(
+        srv.bus(), &_slot, dbus_path, "info.griwes.nonsense.Controller", controller_vtable, this);
     if (ret < 0)
     {
-        throw std::runtime_error(std::string("Failed to create the controller object: ") + strerror(-ret));
+        throw std::runtime_error(
+            std::string("Failed to install the Controller interface at ") + dbus_path + ": "
+            + strerror(-ret));
     }
+}
+
+METHOD_SIGNATURE(controller, start)
+{
+    entity_kind kind;
+    const char * name;
+
+    co_yield log_and_reply_on_error(
+        sd_bus_message_read(message, "ys", &kind, &name), "Failed to parse parameters");
+
+    std::optional<entity> ent = _config.try_get(kind, name);
+
+    if (!ent)
+    {
+        if (kind == entity_kind::namespace_ && std::string_view(name) == "default")
+        {
+            co_return reply_status_const(
+                -ENOENT,
+                "info.griwes.nonsense.NoSuchEntity",
+                "Attempted to start the default netns, which is not configured with nonsense.");
+        }
+        else
+        {
+            co_return reply_status_format(
+                -ENOENT,
+                "info.griwes.nonsense.NoSuchEntity",
+                "Attempted to start an entity that does not exist: %s.%s.",
+                kind_to_prefix(kind),
+                name);
+        }
+    }
+
+    co_await ent->start();
+    co_return reply_status(sd_bus_reply_method_return(message, ""));
+}
+
+METHOD_SIGNATURE(controller, stop)
+{
+    entity_kind kind;
+    const char * name;
+
+    co_yield log_and_reply_on_error(
+        sd_bus_message_read(message, "ys", &kind, &name), "Failed to parse parameters");
+
+    std::optional<entity> ent = _config.try_get(kind, name);
+
+    if (!ent)
+    {
+        if (kind == entity_kind::namespace_ && std::string_view(name) == "default")
+        {
+            co_return reply_status_const(
+                -ENOENT,
+                "info.griwes.nonsense.NoSuchEntity",
+                "Attempted to stop the default netns, which is not configured with nonsense.");
+        }
+        else
+        {
+            co_return reply_status_format(
+                -ENOENT,
+                "info.griwes.nonsense.NoSuchEntity",
+                "Attempted to stop an entity that does not exist: %s.%s.",
+                kind_to_prefix(kind),
+                name);
+        }
+    }
+
+    co_await ent->stop();
+    co_return reply_status(sd_bus_reply_method_return(message, ""));
 }
 }

--- a/daemon/controller.h
+++ b/daemon/controller.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Michał 'Griwes' Dominiak
+ * Copyright © 2019-2020 Michał 'Griwes' Dominiak
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "dbus.h"
+
 extern "C"
 {
     struct sd_bus_slot;
@@ -24,15 +26,21 @@ extern "C"
 namespace nonsensed
 {
 class options;
+class config;
 class configuration;
 class service;
 
 class controller
 {
 public:
-    controller(const options & opts, configuration & config_object, const service & srv);
+    controller(const options & opts, configuration & configuration_object, const service & srv);
+
+    DECLARE_METHOD(start);
+    DECLARE_METHOD(stop);
 
 private:
+    const service & _srv;
     sd_bus_slot * _slot = nullptr;
+    config & _config;
 };
 }

--- a/daemon/dbus.h
+++ b/daemon/dbus.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "async.h"
 #include "bus_slot.h"
 #include "log_helpers.h"
 
@@ -23,7 +24,7 @@
 
 #define DECLARE_METHOD(name)                                                                                 \
     static int method_##name(sd_bus_message *, void *, sd_bus_error *);                                      \
-    int method_##name##_impl(sd_bus_message *, sd_bus_error *)
+    nonsensed::future method_##name##_impl(sd_bus_message *, sd_bus_error *)
 
 #define DECLARE_PROPERTY_GET(name)                                                                           \
     static int property_##name##_get(                                                                        \
@@ -42,7 +43,8 @@
 #define DEFINE_METHOD(class, name)                                                                           \
     int class ::method_##name(sd_bus_message * message, void * userdata, sd_bus_error * error)               \
     {                                                                                                        \
-        return static_cast<class *>(userdata)->method_##name##_impl(message, error);                         \
+        static_cast<class *>(userdata)->method_##name##_impl(message, error);                                \
+        return 1;                                                                                            \
     }
 
 #define DEFINE_PROPERTY_GET(class, name)                                                                     \
@@ -76,7 +78,7 @@
 // member signature macros
 
 #define METHOD_SIGNATURE(class, name)                                                                        \
-    int class ::method_##name##_impl(sd_bus_message * message, sd_bus_error * error)
+    future class ::method_##name##_impl(sd_bus_message * message, sd_bus_error * error)
 
 #define PROPERTY_GET_SIGNATURE(class, name)                                                                  \
     int class ::property_##name##_get_impl(                                                                  \
@@ -95,13 +97,3 @@
         const char * property,                                                                               \
         sd_bus_message * value,                                                                              \
         sd_bus_error * error)
-
-// various macros
-
-#define HANDLE_DBUS_ERROR_RET(message, status)                                                               \
-    if (status < 0)                                                                                          \
-    {                                                                                                        \
-        std::cerr << error_prefix() << "Error: " << message << ": " << strerror(-status) << '\n';            \
-        return -status;                                                                                      \
-    }
-

--- a/daemon/function.h
+++ b/daemon/function.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2020 Michał 'Griwes' Dominiak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+namespace nonsensed
+{
+template<typename Signature>
+struct function;
+
+template<typename Ret, typename... Args>
+struct function<Ret(Args...)>
+{
+public:
+    template<typename F>
+    function(F f)
+        : _data(
+            new F(std::move(f)),
+            +[](void * ptr) { delete reinterpret_cast<F *>(ptr); }),
+
+          _call_operator(+[](void * ptr, Args... args) {
+              return (*reinterpret_cast<F *>(ptr))(std::forward<Args>(args)...);
+          })
+    {
+    }
+
+    Ret operator()(Args... args)
+    {
+        return _call_operator(_data.get(), std::forward<Args>(args)...);
+    }
+
+private:
+    using _call_operator_t = Ret (*)(void *, Args...);
+
+    std::unique_ptr<void, void (*)(void *)> _data;
+    _call_operator_t _call_operator = nullptr;
+};
+}

--- a/daemon/service.cpp
+++ b/daemon/service.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Michał 'Griwes' Dominiak
+ * Copyright © 2019-2020 Michał 'Griwes' Dominiak
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,25 @@ service::service(const options & opts, configuration & config_object)
     {
         throw std::runtime_error(std::string("Failed to acquire service name: ") + strerror(-ret));
     }
+
+    sd_bus_error error = SD_BUS_ERROR_NULL;
+    sd_bus_message * message = nullptr;
+
+    ret = sd_bus_call_method(
+        _bus,
+        "org.freedesktop.systemd1",
+        "/org/freedesktop/systemd1",
+        "org.freedesktop.systemd1.Manager",
+        "Subscribe",
+        &error,
+        &message,
+        "");
+    if (ret < 0)
+    {
+        throw std::runtime_error(std::string("Failed to subscribe to systemd signals: ") + strerror(-ret));
+    }
+
+    sd_bus_message_unref(message);
 
     config_object.install(*this);
 }

--- a/systemd/nonsense-connection-setup
+++ b/systemd/nonsense-connection-setup
@@ -10,19 +10,36 @@ function raii() {
 
 trap raii EXIT
 
-uplink=$(nonsensectl get "${ENTITY}" uplink-entity)
-ip link set "${DOWNLINK}" netns "${uplink}"
+uplink_netns=$(nonsensectl get "${ENTITY}" uplink-netns) || exit 0
+ip link set "${DOWNLINK}" netns "${uplink_netns}"
 
 if [[ "${ENTITY}" == net.* ]]
 then
     downlink_address=$(nonsensectl get "${ENTITY}" downlink-address-masked)
-    ip netns exec "${uplink}" ip addr add "${downlink_address}" dev "${DOWNLINK}"
+    ip netns exec "${uplink_netns}" ip addr add "${downlink_address}" dev "${DOWNLINK}"
+
+    network_address=$(nonsensectl get "${ENTITY}" network-address)
+
+    uplink=$(nonsensectl get "${ENTITY}" uplink-entity)
+    while true
+    do
+        if [[ "${ENTITY}" != net.* ]]
+        then
+            break
+        fi
+
+        uplink_uplink_netns=$(nonsensectl get "${uplink}" uplink-netns) || break
+        uplink_uplink_address=$(nonsensectl get "${uplink}" uplink-address)
+        ip netns exec "${uplink_uplink_netns}" ip route add "${network_address}" via "${uplink_uplink_address}"
+
+        uplink=$(nonsensectl get "${uplink}" uplink-entity) || break
+    done
 else
     bridge=$(nonsensectl get "${ENTITY}" uplink-bridge)
-    ip netns exec "${uplink}" ip link set "${DOWNLINK}" master "${bridge}"
+    ip netns exec "${uplink_netns}" ip link set "${DOWNLINK}" master "${bridge}"
 fi
 
-ip netns exec "${uplink}" ip link set "${DOWNLINK}" up
+ip netns exec "${uplink_netns}" ip link set "${DOWNLINK}" up
 
 uplink_address=$(nonsensectl get "${ENTITY}" uplink-address-masked)
 uplink_device=$(nonsensectl get "${ENTITY}" uplink-device)

--- a/systemd/nonsense-connection-teardown
+++ b/systemd/nonsense-connection-teardown
@@ -15,6 +15,23 @@ ip route delete default
 device=$(nonsensectl get "${ENTITY}" uplink-device) && \
     ip addr flush "${device}"
 
-uplink=$(nonsensectl get "${ENTITY}" uplink-entity) && \
-    ip netns exec "${uplink}" ip link set "${DOWNLINK}" netns "${NETNS}"
+uplink_netns=$(nonsensectl get "${ENTITY}" uplink-netns) && \
+    ip netns exec "${uplink_netns}" ip link set "${DOWNLINK}" netns "${NETNS}"
+
+if [[ "${ENTITY}" == net.* ]]
+then
+    uplink=$(nonsensectl get "${ENTITY}" uplink-entity)
+    while true
+    do
+        if [[ "${ENTITY}" != net.* ]]
+        then
+            break
+        fi
+
+        uplink_uplink_netns=$(nonsensectl get "${uplink}" uplink-netns) || break
+        ip netns exec "${uplink_uplink_netns}" ip route del "${network_address}"
+
+        uplink=$(nonsensectl get "${uplink}" uplink-entity) || break
+    done
+fi
 

--- a/systemd/nonsense-namespace@.target
+++ b/systemd/nonsense-namespace@.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=Nonsense namespace engine namespace target for %I
+
+Requires=nonsense-netns@%i.service
+Wants=nonsense-connection@%i.service
+After=nonsense-netns@%i.service nonsense-connection@%i.service
+

--- a/test/docker/debian-gcc10.Dockerfile
+++ b/test/docker/debian-gcc10.Dockerfile
@@ -7,12 +7,10 @@ RUN apt-get update \
 
 RUN apt-get update \
     && apt-get install -yq build-essential pkg-config cmake libsystemd-dev systemd iproute2 iw nftables bind9 \
-        ccache clang libc++1 libc++abi1 libc++-dev \
+        ccache g++-10 \
     && rm -rf /etc/systemd/system/*
 
-# le sigh
-RUN ln -sf /usr/lib/x86_64-linux-gnu/libc++abi.so.1 /usr/lib/x86_64-linux-gnu/libc++abi.so
-# le sigh #2: make the system not wait until a ttyS0 timeout without CONFIG_FHANDLE
+# le sigh: make the system not wait until a ttyS0 timeout without CONFIG_FHANDLE
 RUN systemctl mask serial-getty@ttyS0.service
 
 COPY . /nonsense
@@ -23,6 +21,6 @@ ENV CCACHE_COMPILERCHECK=content
 RUN rm -rf build \
     && mkdir build \
     && cd build \
-    && CXX="ccache clang++ -stdlib=libc++" LD="ccache clang++ -stdlib=libc++" cmake .. \
+    && CXX="ccache g++-10" LD="ccache g++-10" cmake .. \
     && make install -j$(nproc)
 

--- a/test/docker/fedora-clang.Dockerfile
+++ b/test/docker/fedora-clang.Dockerfile
@@ -1,0 +1,24 @@
+ARG RELEASE=rawehide
+FROM fedora:${RELEASE}
+
+RUN dnf upgrade -y
+
+RUN dnf install -y @development-tools procps cmake systemd-devel systemd iproute iw nftables bind \
+        iputils \
+        ccache clang libcxx-devel
+
+# le sigh: make the system not wait until a ttyS0 timeout without CONFIG_FHANDLE
+RUN systemctl mask serial-getty@ttyS0.service
+RUN ln -sf /usr/lib/systemd/systemd /usr/bin/systemd
+
+COPY . /nonsense
+WORKDIR /nonsense
+
+ENV CCACHE_DIR=/nonsense/cache
+ENV CCACHE_COMPILERCHECK=content
+RUN rm -rf build \
+    && mkdir build \
+    && cd build \
+    && CXX="ccache clang++ -stdlib=libc++" LD="ccache clang++ -stdlib=libc++" cmake .. \
+    && make install -j$(nproc)
+

--- a/test/docker/fedora-gcc.Dockerfile
+++ b/test/docker/fedora-gcc.Dockerfile
@@ -1,0 +1,24 @@
+ARG RELEASE=rawehide
+FROM fedora:${RELEASE}
+
+RUN dnf upgrade -y
+
+RUN dnf install -y @development-tools procps cmake systemd-devel systemd iproute iw nftables bind \
+        iputils \
+        ccache g++
+
+# le sigh: make the system not wait until a ttyS0 timeout without CONFIG_FHANDLE
+RUN systemctl mask serial-getty@ttyS0.service
+RUN ln -sf /usr/lib/systemd/systemd /usr/bin/systemd
+
+COPY . /nonsense
+WORKDIR /nonsense
+
+ENV CCACHE_DIR=/nonsense/cache
+ENV CCACHE_COMPILERCHECK=content
+RUN rm -rf build \
+    && mkdir build \
+    && cd build \
+    && CXX="ccache g++" LD="ccache g++" cmake .. \
+    && make install -j$(nproc)
+

--- a/test/docker/ubuntu-clang.Dockerfile
+++ b/test/docker/ubuntu-clang.Dockerfile
@@ -5,8 +5,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get -yq full-upgrade
 
-RUN apt-get install -yq build-essential pkg-config cmake libsystemd-dev systemd iproute2 iw nftables bind9 \
-    iputils-ping clang libc++1 libc++abi1 libc++-dev \
+RUN apt-get update \
+    && apt-get install -yq build-essential pkg-config cmake libsystemd-dev systemd iproute2 iw nftables bind9 \
+        iputils-ping \
+        ccache clang libc++1 libc++abi1 libc++-dev \
     && rm -rf /etc/systemd/system/*
 
 # le sigh
@@ -17,9 +19,11 @@ RUN systemctl mask serial-getty@ttyS0.service
 COPY . /nonsense
 WORKDIR /nonsense
 
+ENV CCACHE_DIR=/nonsense/cache
+ENV CCACHE_COMPILERCHECK=content
 RUN rm -rf build \
     && mkdir build \
     && cd build \
-    && CXX="clang++ -stdlib=libc++" LD="clang++ -stdlib=libc++" cmake .. \
+    && CXX="ccache clang++ -stdlib=libc++" LD="ccache clang++ -stdlib=libc++" cmake .. \
     && make install -j$(nproc)
 

--- a/test/docker/ubuntu-gcc10.Dockerfile
+++ b/test/docker/ubuntu-gcc10.Dockerfile
@@ -1,5 +1,5 @@
-ARG RELEASE=unstable
-FROM debian:${RELEASE}
+ARG RELEASE=rolling
+FROM ubuntu:${RELEASE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
@@ -7,12 +7,11 @@ RUN apt-get update \
 
 RUN apt-get update \
     && apt-get install -yq build-essential pkg-config cmake libsystemd-dev systemd iproute2 iw nftables bind9 \
-        ccache clang libc++1 libc++abi1 libc++-dev \
+        iputils-ping \
+        ccache g++-10 \
     && rm -rf /etc/systemd/system/*
 
-# le sigh
-RUN ln -sf /usr/lib/x86_64-linux-gnu/libc++abi.so.1 /usr/lib/x86_64-linux-gnu/libc++abi.so
-# le sigh #2: make the system not wait until a ttyS0 timeout without CONFIG_FHANDLE
+# le sigh: make the system not wait until a ttyS0 timeout without CONFIG_FHANDLE
 RUN systemctl mask serial-getty@ttyS0.service
 
 COPY . /nonsense
@@ -23,6 +22,6 @@ ENV CCACHE_COMPILERCHECK=content
 RUN rm -rf build \
     && mkdir build \
     && cd build \
-    && CXX="ccache clang++ -stdlib=libc++" LD="ccache clang++ -stdlib=libc++" cmake .. \
+    && CXX="ccache g++-10" LD="ccache g++-10" cmake .. \
     && make install -j$(nproc)
 

--- a/test/scripts/prepare_environment
+++ b/test/scripts/prepare_environment
@@ -7,9 +7,9 @@ if [[ "${SKIP_UPGRADE}" -ne 1 ]]
 then
     sudo -E apt-get -y full-upgrade
 fi
-sudo -E apt-get -y install git docker.io
+sudo -E apt-get -y install git docker.io ccache
 
-sudo mkdir /cache
+sudo mkdir -p /cache
 sudo chown ${USER}:${USER} /cache
 
 sudo systemctl unmask docker.service

--- a/test/scripts/run_test_suite
+++ b/test/scripts/run_test_suite
@@ -4,7 +4,13 @@ set -e
 
 known_configurations=(
     debian-clang:{testing,unstable}
-    ubuntu-clang:{rolling,devel}
+    debian-gcc10:{testing,unstable}
+
+    ubuntu-clang:{eoan,focal,devel}
+    ubuntu-gcc10:{focal,devel}
+
+    fedora-clang:{31,32,rawhide}
+    fedora-gcc:{32,rawhide}
 )
 
 tmpdir=$(mktemp -d)
@@ -86,6 +92,12 @@ do
 
     echo
     echo "### $(date) ### ${configuration}: build"
+
+    rm -rf ./cache
+    sudo mkdir -p /cache/${configuration}
+    sudo chown ${USER}:${USER} /cache/${configuration}
+    cp -a /cache/${configuration} ./cache
+
     if ! sudo docker build ${DOCKER_BUILD_PULL} \
         --build-arg=RELEASE=${release} \
         -f test/docker/${distro}.Dockerfile \
@@ -94,6 +106,12 @@ do
         echo "### $(date) ### ${configuration}: build failure" | tee -a ${tmpdir}/results
         continue
     fi
+
+    sudo docker run --rm \
+        --mount type=bind,source=/cache/${configuration},destination=/host-cache \
+        nonsense/${configuration} \
+        cp -a /nonsense/cache/. /host-cache
+    CCACHE_DIR=/cache/${configuration} ccache --cleanup
 
     for test in $(find test/suite -name "*.test" | sed 's:^test/suite/::' | sort -n)
     do
@@ -112,6 +130,7 @@ do
             flags=$(test/suite/${test}.setup pre ${tmpdir})
         fi
 
+        mkdir -p "/cache/${configuration}"
         container=$(sudo docker run --rm -d \
             --privileged \
             --tmpfs /run \
@@ -135,7 +154,7 @@ do
                 bash -ex /nonsense/test/suite/${test} 2>&1 \
                     || {
                         printf '\nNonsense services status:\n'
-                        systemctl status 'nonsense*.service'
+                        systemctl status 'nonsense*'
 
                         printf '\nNonsense journal entries:\n'
                         journalctl -u 'nonsense*'
@@ -168,6 +187,8 @@ do
         fi
     done
 done
+
+sudo docker system prune -f
 
 if [[ -f ${tmpdir}/results ]]
 then

--- a/test/suite/2.network/2.uplink-default.test
+++ b/test/suite/2.network/2.uplink-default.test
@@ -1,15 +1,12 @@
 # set the test parameters
-export UPLINK_EXEC="ip netns exec uplink"
+export UPLINK_EXEC=""
 export TARGET_IP=10.0.0.1
 export UPLINK="ns.uplink"
 export IMMEDIATE=1
 
-# create the uplink namespace
-ip netns add uplink
-
 # setup nonsense
 token=$(nonsensectl get new-transaction-token)
-nonsensectl -t ${token} add namespace uplink type netns-external
+nonsensectl -t ${token} add namespace uplink type netns-default role root
 nonsensectl -t ${token} commit
 
 # run the test
@@ -17,3 +14,4 @@ test_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 bash -exu "${test_dir}/uplink.template"
 
 # vim: ft=sh
+

--- a/test/suite/2.network/3.uplink.test
+++ b/test/suite/2.network/3.uplink.test
@@ -1,15 +1,12 @@
 # set the test parameters
-export UPLINK_EXEC="ip netns exec uplink"
+export UPLINK_EXEC="ip netns exec nonsense:uplink"
 export TARGET_IP=10.0.0.1
 export UPLINK="ns.uplink"
 export IMMEDIATE=1
 
-# create the uplink namespace
-ip netns add uplink
-
 # setup nonsense
 token=$(nonsensectl get new-transaction-token)
-nonsensectl -t ${token} add namespace uplink type netns-external
+nonsensectl -t ${token} add namespace uplink type netns role root
 nonsensectl -t ${token} commit
 
 # run the test
@@ -17,3 +14,4 @@ test_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 bash -exu "${test_dir}/uplink.template"
 
 # vim: ft=sh
+

--- a/test/suite/2.network/4.uplink-client.test
+++ b/test/suite/2.network/4.uplink-client.test
@@ -1,0 +1,8 @@
+token=$(nonsensectl get new-transaction-token)
+nonsensectl -t ${token} add namespace uplink type netns-default role client
+nonsensectl -t ${token} add network test address 192.168.2.0/24 uplink ns.uplink
+! (nonsensectl -t ${token} commit \
+    && echo 'this should fail, because a client namespace should not be allowed as an uplink')
+
+# vim: ft=sh
+

--- a/test/suite/2.network/5.uplink-network.test
+++ b/test/suite/2.network/5.uplink-network.test
@@ -1,15 +1,12 @@
 # set the test parameters
-export UPLINK_EXEC="ip netns exec uplink"
+export UPLINK_EXEC="ip netns exec nonsense:root"
 export TARGET_IP=10.0.0.1
-export UPLINK="ns.uplink"
-export IMMEDIATE=1
-
-# create the uplink namespace
-ip netns add uplink
+export UPLINK="net.uplink"
 
 # setup nonsense
 token=$(nonsensectl get new-transaction-token)
-nonsensectl -t ${token} add namespace uplink type netns-external
+nonsensectl -t ${token} add namespace root type netns role root
+nonsensectl -t ${token} add network uplink address 192.168.10.0/24 uplink ns.root
 nonsensectl -t ${token} commit
 
 # run the test
@@ -17,3 +14,4 @@ test_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 bash -exu "${test_dir}/uplink.template"
 
 # vim: ft=sh
+

--- a/test/suite/2.network/6.uplink-network-network.test
+++ b/test/suite/2.network/6.uplink-network-network.test
@@ -1,0 +1,18 @@
+# set the test parameters
+export UPLINK_EXEC="ip netns exec nonsense:root"
+export TARGET_IP=10.0.0.1
+export UPLINK="net.uplink"
+
+# setup nonsense
+token=$(nonsensectl get new-transaction-token)
+nonsensectl -t ${token} add namespace root type netns role root
+nonsensectl -t ${token} add network middle address 192.168.10.0/24 uplink ns.root
+nonsensectl -t ${token} add network uplink address 192.168.20.0/24 uplink net.middle
+nonsensectl -t ${token} commit
+
+# run the test
+test_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+bash -exu "${test_dir}/uplink.template"
+
+# vim: ft=sh
+

--- a/test/suite/2.network/uplink.template
+++ b/test/suite/2.network/uplink.template
@@ -1,0 +1,63 @@
+TARGET_IP=${TARGET_IP}
+IMMEDIATE=${IMMEDIATE:-0}
+
+# setup the nonsense configuration
+token=$(nonsensectl get new-transaction-token)
+nonsensectl -t ${token} add network test address 192.168.2.0/24 uplink ${UPLINK}
+nonsensectl -t ${token} commit
+
+# check that the service starts successfully
+nonsensectl start net.test
+systemctl is-system-running
+
+# setup the uplink IP
+${UPLINK_EXEC} ip addr add ${TARGET_IP}/32 dev lo
+
+${UPLINK_EXEC} ip link
+${UPLINK_EXEC} ip addr
+${UPLINK_EXEC} ip route
+ip netns exec nonsense:net.test ip link
+ip netns exec nonsense:net.test ip addr
+ip netns exec nonsense:net.test ip route
+
+# test devices and routes
+if [[ "${IMMEDIATE}" -eq 1 ]]
+then
+    ${UPLINK_EXEC} ip link | grep -q 'nd-net.test'
+    ${UPLINK_EXEC} ip route | grep 192.168.2.0/24 | grep -q 'dev nd-net.test'
+fi
+ip netns exec nonsense:net.test ip route | grep default | grep -q 'dev nb-test'
+
+# test connectivity
+ip netns exec nonsense:net.test ping -c 1 -W 1 192.168.2.1
+ip netns exec nonsense:net.test ping -c 1 -W 1 ${TARGET_IP}
+${UPLINK_EXEC} ping -c 1 -W 1 192.168.2.2
+
+# check tha the service shuts down successfully
+nonsensectl stop net.test
+systemctl is-system-running
+
+if [[ "${IMMEDIATE}" -eq 1 ]]
+then
+    ! ${UPLINK_EXEC} ip link | grep -q 'nd-net.test'
+    ! ${UPLINK_EXEC} ip route | grep -q 192.168.2.0/24
+fi
+! ip netns exec nonsense:net.test ip route | grep -q default
+
+# check that restarting the service also works correctly
+nonsensectl start net.test
+systemctl is-system-running
+
+if [[ "${IMMEDIATE}" -eq 1 ]]
+then
+    ${UPLINK_EXEC} ip link | grep -q 'nd-net.test'
+    ${UPLINK_EXEC} ip route | grep 192.168.2.0/24 | grep -q 'dev nd-net.test'
+fi
+ip netns exec nonsense:net.test ip route | grep default | grep -q 'dev nb-test'
+
+ip netns exec nonsense:net.test ping -c 1 -W 1 192.168.2.1
+ip netns exec nonsense:net.test ping -c 1 -W 1 ${TARGET_IP}
+${UPLINK_EXEC} ping -c 1 -W 1 192.168.2.2
+
+# vim: ft=sh
+


### PR DESCRIPTION
* `nonsensectl` learned to start and stop entities.
* A significant part of the daemon is now powered by coroutines (whichz
also allows to use the sdbus async APIs in a non-insane way).
* Add Fedora testing configurations.
* Add uplink tests for networks, to test many different possible
configurations of network uplinks.
* Use nonsensectl start and stop in the uplink tests.
* Use ccache in the vagrant image to speed up building docker images.