### PR TITLE
Support foreign-architecture testing with Debian images.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,28 +16,53 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch:
+
+        - amd64
+        - arm64v8
+        - ppc64le
+        - mips64le
+
         config:
 
         - "debian-clang:testing"
         - "debian-clang:unstable"
 
-        - "debian-gcc10:testing"
-        - "debian-gcc10:unstable"
+        - "debian-gcc:testing"
+        - "debian-gcc:unstable"
 
-        - "ubuntu-clang:latest"
-        - "ubuntu-clang:rolling"
-        - "ubuntu-clang:devel"
+        include:
 
-        - "ubuntu-gcc10:latest"
-        - "ubuntu-gcc10:rolling"
-        - "ubuntu-gcc10:devel"
+        # The tests need nft of the host arch, but it's not possible to easily get that on Ubuntu.
+        # dpkg --add-architecture amd64... works like in Debian, but... the paths of the repositories
+        # seem to be weird. Specifically, all the non-amd64 versions seem to use a "ports" repo...?
+        # And the URLs they use mean that trying to add amd64 results in an attempt to fetch the list
+        # of packages in a binary-amd64 "ports" repo, which doesn't exist.
+        #
+        # Great repo design, Ubuntu.
+        #
+        # Limit the Ubuntu tests to just amd64.
 
-        - "fedora-clang:31"
-        - "fedora-clang:32"
-        - "fedora-clang:latest"
+        - { arch: "amd64", config: "ubuntu-clang:latest" }
+        - { arch: "amd64", config: "ubuntu-clang:rolling" }
+        - { arch: "amd64", config: "ubuntu-clang:devel" }
 
-        - "fedora-gcc:32"
-        - "fedora-gcc:latest"
+        - { arch: "amd64", config: "ubuntu-gcc10:latest" }
+        - { arch: "amd64", config: "ubuntu-gcc:rolling" }
+        - { arch: "amd64", config: "ubuntu-gcc:devel" }
+
+        # The tests need nft of the host arch, but it's not possible to easily get that on Fedora;
+        # trying to install "foreign" packages just results in a conflict between the native and
+        # foreign libc packages.
+        #
+        # Limit the Fedora tests to just amd64.
+
+        - { arch: "amd64", config: "fedora-clang:31" }
+        - { arch: "amd64", config: "fedora-clang:32" }
+        - { arch: "amd64", config: "fedora-clang:latest" }
+
+        - { arch: "amd64", config: "fedora-gcc:32" }
+        - { arch: "amd64", config: "fedora-gcc:latest" }
 
     runs-on: ubuntu-latest
 
@@ -53,4 +78,4 @@ jobs:
       run: /nonsense/test/scripts/prepare_environment
 
     - name: Run tests
-      run: /nonsense/test/scripts/run_test_suite -d ${{ matrix.config }}
+      run: /nonsense/test/scripts/run_test_suite -d ${{ matrix.config }} -a ${{ matrix.arch }}

--- a/daemon/async.h
+++ b/daemon/async.h
@@ -259,16 +259,16 @@ public:
                 return false;
             }
 
-            coro::coroutine_handle<> await_suspend(coro::coroutine_handle<> handle)
+            bool await_suspend(coro::coroutine_handle<> handle)
             {
                 if (status.code < 0)
                 {
                     promise_.return_value(reply_status_t{ status.code });
                     handle.destroy();
-                    return coro::noop_coroutine();
+                    return true;
                 }
 
-                return handle;
+                return false;
             }
 
             void await_resume()

--- a/daemon/entity.cpp
+++ b/daemon/entity.cpp
@@ -164,7 +164,7 @@ subtask entity::start()
         sd_bus * raw_bus;
         co_yield log_and_reply_on_error(sd_bus_new(&raw_bus), "Failed to allocate an sd_bus");
 
-        _entity_state state = { .pid = pid, .bus = _entity_state::bus_ptr(sd_bus_ref(raw_bus)) };
+        _entity_state state = { .pid = pid, .bus = _entity_state::bus_ptr(raw_bus) };
         _live_entities.emplace(_name, std::move(state));
 
         co_yield log_and_reply_on_error(sd_bus_set_fd(raw_bus, sv[0], sv[0]), "Failed to set bus fd");

--- a/test/docker/debian-clang.Dockerfile
+++ b/test/docker/debian-clang.Dockerfile
@@ -1,19 +1,25 @@
+ARG ARCH=
 ARG RELEASE=unstable
-FROM debian:${RELEASE}
+FROM ${ARCH}debian:${RELEASE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get -yq full-upgrade
 
+ARG HOST=amd64
+RUN dpkg --add-architecture ${HOST}
+
 RUN apt-get update \
-    && apt-get install -yq build-essential pkg-config cmake libsystemd-dev systemd iproute2 iw nftables bind9 \
-        ccache clang libc++1 libc++abi1 libc++-dev \
+    && apt-get install -yq build-essential pkg-config cmake libsystemd-dev systemd iproute2 iw nftables:${HOST} bind9 \
+        ccache clang lld libc++1 libc++abi1 libc++-dev \
     && rm -rf /etc/systemd/system/*
 
 # le sigh
-RUN ln -sf /usr/lib/x86_64-linux-gnu/libc++abi.so.1 /usr/lib/x86_64-linux-gnu/libc++abi.so
+RUN ln -sf /usr/lib/$(gcc -dumpmachine)/libc++abi.so.1 /usr/lib/$(gcc -dumpmachine)/libc++abi.so
 # le sigh #2: make the system not wait until a ttyS0 timeout without CONFIG_FHANDLE
 RUN systemctl mask serial-getty@ttyS0.service
+# le sigh: this fails to mount when running through binfmt
+RUN systemctl mask proc-sys-fs-binfmt_misc.automount
 
 COPY . /nonsense
 WORKDIR /nonsense
@@ -23,6 +29,6 @@ ENV CCACHE_COMPILERCHECK=content
 RUN rm -rf build \
     && mkdir build \
     && cd build \
-    && CXX="ccache clang++ -stdlib=libc++" LD="ccache clang++ -stdlib=libc++" cmake .. -DENABLE_TESTS=ON \
+    && CXX="ccache clang++ -stdlib=libc++" LD="ccache clang++ -stdlib=libc++" LDFLAGS="-fuse-ld=$(which ld.lld)" cmake .. -DENABLE_TESTS=ON \
     && make install -j$(nproc)
 

--- a/test/docker/debian-gcc.Dockerfile
+++ b/test/docker/debian-gcc.Dockerfile
@@ -1,15 +1,17 @@
 ARG ARCH=
-ARG RELEASE=rolling
-FROM ${ARCH}ubuntu:${RELEASE}
+ARG RELEASE=unstable
+FROM ${ARCH}debian:${RELEASE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get -yq full-upgrade
 
+ARG HOST=amd64
+RUN dpkg --add-architecture ${HOST}
+
 RUN apt-get update \
-    && apt-get install -yq build-essential pkg-config cmake libsystemd-dev systemd iproute2 iw nftables bind9 \
-        iputils-ping \
-        ccache g++-10 \
+    && apt-get install -yq build-essential pkg-config cmake libsystemd-dev systemd iproute2 iw nftables:${HOST} bind9 \
+        ccache g++ \
     && rm -rf /etc/systemd/system/*
 
 # le sigh: make the system not wait until a ttyS0 timeout without CONFIG_FHANDLE
@@ -25,6 +27,5 @@ ENV CCACHE_COMPILERCHECK=content
 RUN rm -rf build \
     && mkdir build \
     && cd build \
-    && CXX="ccache g++-10" LD="ccache g++-10" cmake .. -DENABLE_TESTS=ON \
+    && CXX="ccache g++" LD="ccache g++" cmake .. -DENABLE_TESTS=ON \
     && make install -j$(nproc)
-

--- a/test/docker/fedora-clang.Dockerfile
+++ b/test/docker/fedora-clang.Dockerfile
@@ -11,6 +11,8 @@ RUN dnf install -y @development-tools procps cmake systemd-devel systemd iproute
 RUN systemctl mask serial-getty@ttyS0.service
 # le sigh: this fails to mount when running through binfmt
 RUN systemctl mask proc-sys-fs-binfmt_misc.automount
+# le sigh: sometimes leading to degrated state for no reason
+RUN systemctl disable dnf-makecache.timer
 RUN systemctl mask systemd-resolved.service
 RUN ln -sf /usr/lib/systemd/systemd /usr/bin/systemd
 

--- a/test/docker/fedora-clang.Dockerfile
+++ b/test/docker/fedora-clang.Dockerfile
@@ -5,10 +5,12 @@ RUN dnf upgrade -y
 
 RUN dnf install -y @development-tools procps cmake systemd-devel systemd iproute iw nftables bind \
         iputils \
-        ccache clang libcxx-devel
+        ccache clang lld libcxx-devel
 
 # le sigh: make the system not wait until a ttyS0 timeout without CONFIG_FHANDLE
 RUN systemctl mask serial-getty@ttyS0.service
+# le sigh: this fails to mount when running through binfmt
+RUN systemctl mask proc-sys-fs-binfmt_misc.automount
 RUN systemctl mask systemd-resolved.service
 RUN ln -sf /usr/lib/systemd/systemd /usr/bin/systemd
 
@@ -20,6 +22,6 @@ ENV CCACHE_COMPILERCHECK=content
 RUN rm -rf build \
     && mkdir build \
     && cd build \
-    && CXX="ccache clang++ -stdlib=libc++" LD="ccache clang++ -stdlib=libc++" cmake .. -DENABLE_TESTS=ON \
+    && CXX="ccache clang++ -stdlib=libc++" LD="ccache clang++ -stdlib=libc++" LDFLAGS="-fuse-ld=$(which ld.lld)" cmake .. -DENABLE_TESTS=ON \
     && make install -j$(nproc)
 

--- a/test/docker/fedora-gcc.Dockerfile
+++ b/test/docker/fedora-gcc.Dockerfile
@@ -9,6 +9,8 @@ RUN dnf install -y @development-tools procps cmake systemd-devel systemd iproute
 
 # le sigh: make the system not wait until a ttyS0 timeout without CONFIG_FHANDLE
 RUN systemctl mask serial-getty@ttyS0.service
+# le sigh: this fails to mount when running through binfmt
+RUN systemctl mask proc-sys-fs-binfmt_misc.automount
 RUN systemctl mask systemd-resolved.service
 RUN ln -sf /usr/lib/systemd/systemd /usr/bin/systemd
 

--- a/test/docker/fedora-gcc.Dockerfile
+++ b/test/docker/fedora-gcc.Dockerfile
@@ -11,6 +11,8 @@ RUN dnf install -y @development-tools procps cmake systemd-devel systemd iproute
 RUN systemctl mask serial-getty@ttyS0.service
 # le sigh: this fails to mount when running through binfmt
 RUN systemctl mask proc-sys-fs-binfmt_misc.automount
+# le sigh: sometimes leading to degrated state for no reason
+RUN systemctl disable dnf-makecache.timer
 RUN systemctl mask systemd-resolved.service
 RUN ln -sf /usr/lib/systemd/systemd /usr/bin/systemd
 

--- a/test/docker/ubuntu-gcc.Dockerfile
+++ b/test/docker/ubuntu-gcc.Dockerfile
@@ -1,5 +1,5 @@
-ARG RELEASE=unstable
-FROM debian:${RELEASE}
+ARG RELEASE=rolling
+FROM ubuntu:${RELEASE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
@@ -7,11 +7,14 @@ RUN apt-get update \
 
 RUN apt-get update \
     && apt-get install -yq build-essential pkg-config cmake libsystemd-dev systemd iproute2 iw nftables bind9 \
-        ccache g++-10 \
+        iputils-ping \
+        ccache g++ \
     && rm -rf /etc/systemd/system/*
 
 # le sigh: make the system not wait until a ttyS0 timeout without CONFIG_FHANDLE
 RUN systemctl mask serial-getty@ttyS0.service
+# le sigh: this fails to mount when running through binfmt
+RUN systemctl mask proc-sys-fs-binfmt_misc.automount
 
 COPY . /nonsense
 WORKDIR /nonsense
@@ -21,6 +24,6 @@ ENV CCACHE_COMPILERCHECK=content
 RUN rm -rf build \
     && mkdir build \
     && cd build \
-    && CXX="ccache g++-10" LD="ccache g++-10" cmake .. -DENABLE_TESTS=ON \
+    && CXX="ccache g++" LD="ccache g++" cmake .. -DENABLE_TESTS=ON \
     && make install -j$(nproc)
 

--- a/test/scripts/run_test_suite
+++ b/test/scripts/run_test_suite
@@ -4,10 +4,11 @@ set -e
 
 known_configurations=(
     debian-clang:{testing,unstable}
-    debian-gcc10:{testing,unstable}
+    debian-gcc:{testing,unstable}
 
     ubuntu-clang:{latest,rolling,devel}
-    ubuntu-gcc10:{latest,rolling,devel}
+    ubuntu-gcc10:latest
+    ubuntu-gcc:{rolling,devel}
 
     fedora-clang:{31,32,latest}
     fedora-gcc:{32,latest}
@@ -22,6 +23,7 @@ trap cleanup EXIT
 
 function print_help() {
     echo "### Valid flags are:"
+    echo "### -a/--arch arch - run on the specified architecture"
     echo "### -d/--distribution distro:release - only run matching configurations (both distro and release are patterns)"
     echo "### -t/--testcase testcase - only run matching testcases (testcase is a pattern)"
     echo "### -f/--ignore-fatal - don't interrupt a test flow for a configuration after encountering fatal failure"
@@ -34,6 +36,17 @@ DOCKER_BUILD_PULL="--pull"
 while [[ $# -gt 0 ]]
 do
     case "$1" in
+        -a|--arch)
+            shift
+            ARCH=$1/
+            arch_string="${1} ### "
+            echo "### Requested architecture: ${1}"
+            shift
+
+            sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+            ;;
+
         -d|--distribution)
             shift
             IFS=':' read DISTRO RELEASE <<<$1
@@ -90,26 +103,36 @@ do
         continue
     fi
 
+    if [[ "${ARCH}" != "" && "${ARCH}" != "amd64/" && "${distro}" != debian-* ]]
+    then
+        echo "### Only Debian images support non-amd64 target architectures."
+        echo "### '-d ${distro}:${release}' is not supported with '-a ${ARCH::-1}'."
+
+        exit 1
+    fi
+
     echo
-    echo "### $(date) ### ${configuration}: build"
+    echo "### $(date) ### ${arch_string}${configuration}: build"
 
     rm -rf ./cache
-    sudo mkdir -p /cache/${configuration}
-    sudo chown ${USER}:${USER} /cache/${configuration}
-    cp -a /cache/${configuration} ./cache
+    sudo mkdir -p /cache/${ARCH}${configuration}
+    sudo chown ${USER}:${USER} /cache/${ARCH}${configuration}
+    cp -a /cache/${ARCH}${configuration} ./cache
 
     if ! sudo docker build ${DOCKER_BUILD_PULL} \
+        --build-arg=ARCH=${ARCH} \
+        --build-arg=HOST=$(dpkg --print-architecture) \
         --build-arg=RELEASE=${release} \
         -f test/docker/${distro}.Dockerfile \
-        --tag nonsense/${configuration} .
+        --tag nonsense/${ARCH}${configuration} .
     then
-        echo "### $(date) ### ${configuration}: build failure" | tee -a ${tmpdir}/results
+        echo "### $(date) ### ${arch_string}${configuration}: build failure" | tee -a ${tmpdir}/results
         continue
     fi
 
     sudo docker run --rm \
-        --mount type=bind,source=/cache/${configuration},destination=/host-cache \
-        nonsense/${configuration} \
+        --mount type=bind,source=/cache/${ARCH}${configuration},destination=/host-cache \
+        nonsense/${ARCH}${configuration} \
         cp -a /nonsense/cache/. /host-cache
     CCACHE_DIR=/cache/${configuration} ccache --cleanup
 
@@ -121,7 +144,7 @@ do
         fi
 
         echo
-        echo "### $(date) ### ${configuration}: ${test}: running..."
+        echo "### $(date) ### ${arch_string}${configuration}: ${test}: running..."
 
         fatal=0
         flags=
@@ -130,7 +153,6 @@ do
             flags=$(test/suite/${test}.setup pre ${tmpdir})
         fi
 
-        mkdir -p "/cache/${configuration}"
         container=$(sudo docker run --rm -d \
             --privileged \
             --tmpfs /run \
@@ -138,7 +160,7 @@ do
             --tmpfs /tmp \
             -v /sys/fs/cgroup:/sys/fs/cgroup \
             ${flags} \
-            nonsense/${configuration} systemd)
+            nonsense/${ARCH}${configuration} systemd)
 
         # allow a few seconds for dbus to stand up (otherwise random failures would accur not exactly rarely)
         # but only if it is not up at the point of doing docker exec
@@ -146,10 +168,10 @@ do
         # and then check the status
         if ! sudo docker exec ${container} bash -e -c '
                 i=3; if [[ "$i" -ne 0 ]] && ! pgrep dbus-daemon | grep "" -q; then sleep 1; i=$((i-1)); fi
-                systemctl is-system-running --wait && systemctl status
+                systemctl is-system-running --wait && systemctl status || { systemctl status; systemctl; false; }
             ' >/dev/null
         then
-            echo "### $(date) ### ${configuration}: ${test}: setup failure" | tee -a ${tmpdir}/results
+            echo "### $(date) ### ${arch_string}${configuration}: ${test}: setup failure" | tee -a ${tmpdir}/results
         elif sudo docker exec ${container} bash -c "
                 bash -ex /nonsense/test/suite/${test} 2>&1 \
                     || {
@@ -163,15 +185,15 @@ do
                     }
             " >${tmpdir}/log
         then
-            echo "### $(date) ### ${configuration}: ${test}: success"
+            echo "### $(date) ### ${arch_string}${configuration}: ${test}: success"
         else
             cat ${tmpdir}/log
             if [[ -f test/suite/${test}.fatal ]]
             then
-                echo "### $(date) ### ${configuration}: ${test}: fatal failure" | tee -a ${tmpdir}/results
+                echo "### $(date) ### ${arch_string}${configuration}: ${test}: fatal failure" | tee -a ${tmpdir}/results
                 fatal=1
             else
-                echo "### $(date) ### ${configuration}: ${test}: failure" | tee -a ${tmpdir}/results
+                echo "### $(date) ### ${arch_string}${configuration}: ${test}: failure" | tee -a ${tmpdir}/results
             fi
         fi
         sudo docker kill ${container} >/dev/null

--- a/test/scripts/run_test_suite
+++ b/test/scripts/run_test_suite
@@ -168,13 +168,16 @@ do
         # and then check the status
         if ! sudo docker exec ${container} bash -e -c '
                 i=3; if [[ "$i" -ne 0 ]] && ! pgrep dbus-daemon | grep "" -q; then sleep 1; i=$((i-1)); fi
-                systemctl is-system-running --wait && systemctl status || { systemctl status; systemctl; false; }
+                systemctl is-system-running --wait && systemctl status || { systemctl status >&2; systemctl >&2; false; }
             ' >/dev/null
         then
             echo "### $(date) ### ${arch_string}${configuration}: ${test}: setup failure" | tee -a ${tmpdir}/results
         elif sudo docker exec ${container} bash -c "
                 bash -ex /nonsense/test/suite/${test} 2>&1 \
                     || {
+                        printf '\nSystem state:\n'
+                        systemctl
+
                         printf '\nNonsense services status:\n'
                         systemctl status 'nonsense*'
 


### PR DESCRIPTION
Move the *-clang images to use lld as the linker. (This was necessary to get clang builds working for Debian mips64el, but seems like a good idea in general).

Make all gcc configurations, except for the latest Ubuntu LTS, install `gcc` instead of `gcc-10` now that GCC 10 is the default version on all of them.

Fix a stack overflow that would happen in the loop waiting for the entityd dbus connection to finish initializing. I used to use
synchronous coroutine transfer there, which turns out to be a *very* bad idea in a loop. This happened quite often on the Fedora images, and all the time on the qemu-user-static-powered foreign images. Now it's using the bool-returning form of `await_suspend` instead.